### PR TITLE
fix: task-a733-vpu: modify depend package name to the latest

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -78,7 +78,7 @@ Description: Metapackage for common A527 vendor packages
 Package: task-a733-vpu
 Architecture: all
 Priority: optional
-Depends: libcedarc-dev-2.0.0-arm64.deb,
+Depends: libcedarc-dev-2.0.0-arm64 | libcedarc-dev-2.0.0-arm64.deb,
          libgstreamer-openmax-allwinner,
          ${misc:Depends},
 Description: Metapackage for A733 X.Org support


### PR DESCRIPTION
Link: https://github.com/radxa-pkg/allwinner-prebuilt-extra/releases/tag/0.1.3